### PR TITLE
Polish tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # parking-lot-manager-tests
 
-Automated API test suite for the **Pango Pay & Go – Parking Lot Manager**.
-The suite is built with `pytest`, `requests`, and `python-dotenv` and
-covers core parking workflows.
+Automated test suite for the **Pango Pay & Go – Parking Lot Manager**.
+API tests use `pytest`, `requests`, and `python-dotenv` while a single UI
+scenario is covered with `pytest-playwright`.
 
 ## Setup
 1. Install dependencies:
@@ -21,10 +21,21 @@ covers core parking workflows.
    Note: The credentials will be provided securely by the test author (via email or other private means). Please do not attempt to run the tests without updating the .env file.
 
 ## Running Tests
-Ensure the Parking Lot Manager application is running locally and then execute:
+Ensure the Parking Lot Manager application is running locally. Install the
+Playwright browsers once:
+```bash
+playwright install
+```
+
+Run the full test suite:
 ```bash
 pytest
 ```
 
-The suite includes tests for starting and ending parking sessions, as well as
-checks for preventing duplicate parking attempts.
+Run only the UI test:
+```bash
+pytest -m ui
+```
+
+The suite includes tests for starting parking sessions and preventing duplicate
+parking attempts. See `TEST_PLAN.md` for a detailed description of coverage.

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -1,0 +1,18 @@
+# Test Plan
+
+## API Tests
+
+| ID  | Description                                   |
+| --- | --------------------------------------------- |
+| TC1 | Start parking with valid data                 |
+| TC2 | Duplicate start parking from same user        |
+| TC3 | Duplicate start parking from different user   |
+
+## UI Tests
+
+| ID  | Description                                   |
+| --- | --------------------------------------------- |
+| TC3 | Duplicate start parking, different user (UI)  |
+
+Each test runs independently with unique license plates (except the UI test,
+which uses a fixed plate) and authenticates via user credentials from `.env`.

--- a/tests/test_start_parking.py
+++ b/tests/test_start_parking.py
@@ -1,11 +1,8 @@
 """Tests related to *starting* parking sessions."""
 
-import pytest
-
 from utils.api import start_parking, count_plate_occurrences
 
 
-@pytest.mark.usefixtures("session", "base_url", "unique_plate")
 def test_tc1_start_parking_valid(session, base_url, unique_plate):
     """TC1 – Start Parking (Valid)."""
     resp = start_parking(session, base_url, unique_plate)
@@ -15,7 +12,6 @@ def test_tc1_start_parking_valid(session, base_url, unique_plate):
     assert count_plate_occurrences(dashboard.text, unique_plate) == 1
 
 
-@pytest.mark.usefixtures("session", "base_url", "unique_plate")
 def test_tc2_duplicate_start_same_user(session, base_url, unique_plate):
     """TC2 – Duplicate Start (same user). 2nd request should be ignored."""
     start_parking(session, base_url, unique_plate)
@@ -26,7 +22,6 @@ def test_tc2_duplicate_start_same_user(session, base_url, unique_plate):
     assert count_plate_occurrences(dashboard.text, unique_plate) == 1
 
 
-@pytest.mark.usefixtures("session", "alt_session", "base_url", "unique_plate")
 def test_tc3_duplicate_start_different_user(
     session,
     alt_session,

--- a/utils/api.py
+++ b/utils/api.py
@@ -89,32 +89,9 @@ def start_parking(
         "slot": slot,
         "submit": "Start",
     }
-    return session.post(f"{base_url}/start", data=data, files=files, allow_redirects=True)
-
-
-def end_parking(
-    session: requests.Session,
-    base_url: str,
-    parking_id: str,
-) -> requests.Response:
-    """Close an active parking session by *parking_id*."""
-    token = get_csrf_token(session, base_url, "/")
-    data = {"csrf_token": token, "submit": "End"}
-    return session.post(f"{base_url}/end/{parking_id}", data=data, allow_redirects=True)
-
-
-# ───────────────────────────────  HTML UTILS  ──────────────────────────
-
-
-def find_parking_id(html: str, plate: str) -> Optional[str]:
-    """Return the /end/<id> for *plate* from dashboard HTML."""
-    soup = BeautifulSoup(html, "html.parser")
-    for row in soup.select("tr"):
-        if plate in row.get_text():
-            link = row.find("a", href=lambda h: h and h.startswith("/end/"))
-            if link:
-                return link["href"].rstrip("/").split("/")[-1]
-    return None
+    return session.post(
+        f"{base_url}/start", data=data, files=files, allow_redirects=True
+    )
 
 
 def count_plate_occurrences(html: str, plate: str) -> int:


### PR DESCRIPTION
## Summary
- streamline API helper by removing unused endpoint helpers
- simplify API tests and remove redundant fixture markers
- document setup and add a concise test plan

## Testing
- `pytest` *(fails: Auth failed; missing Playwright deps)*
- `playwright install`

------
https://chatgpt.com/codex/tasks/task_e_689494b142dc832ebdb2027819a762c2