### PR TITLE
Enable local parallel API tests; add .env hygiene; update README

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-BASE_URL=http://localhost:5000
-USERNAME=will_be_provided_securely
-PASSWORD=will_be_provided_securely
-ALT_USERNAME=will_be_provided_securely
-ALT_PASSWORD=will_be_provided_securely

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+BASE_URL=http://localhost:5000
+USERNAME=admin
+PASSWORD=password
+ALT_USERNAME=blabla
+ALT_PASSWORD=12345

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,8 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
+!.env.example
 .envrc
 .venv
 env/

--- a/README.md
+++ b/README.md
@@ -1,42 +1,43 @@
-# parking-lot-manager-tests
+# Parking Lot Manager Tests
 
-Automated test suite for the **Pango Pay & Go – Parking Lot Manager**.
-API tests use `pytest`, `requests`, and `python-dotenv` while a single UI
-scenario is covered with `pytest-playwright`.
+Automated tests for the Parking Lot Manager app (API + UI).
 
-## Setup
-1. Install dependencies:
-   ```bash
-   pip install -r requirements.txt
-   ```
-2. Configure environment variables in `.env` (sample values are provided):
-   ```env
-   BASE_URL=http://localhost:5000
-   USERNAME=will_be_provided_securely
-   PASSWORD=will_be_provided_securely
-   ALT_USERNAME=will_be_provided_securely
-   ALT_PASSWORD=will_be_provided_securely
-   ```
+## Prerequisites
+- Python 3.10+
+- Install Playwright browsers:
+  ```bash
+  playwright install --with-deps
+  ```
 
-   Note: The credentials will be provided securely by the test author (via email or other private means). Please do not attempt to run the tests without updating the .env file.
+## Environment Variables
+Create a `.env` from the template:
+```bash
+cp .env.example .env
+```
+Update values if needed. **Do not commit `.env`.**
+
+## Install Dependencies
+```bash
+pip install -r requirements.txt
+```
+This includes `pytest-xdist` for parallel execution.
 
 ## Running Tests
-Ensure the Parking Lot Manager application is running locally. Install the
-Playwright browsers once:
+**API tests (parallel):**
 ```bash
-playwright install
+pytest -m api -n auto -q
 ```
 
-Run the full test suite:
+**UI tests (serial):**
 ```bash
-pytest
+pytest -m ui -n 1 -q
 ```
 
-Run only the UI test:
+**All (API parallel, UI serial):**
 ```bash
-pytest -m ui
+pytest -m "api" -n auto -q && pytest -m "ui" -n 1 -q
 ```
 
-## Documentation
-The suite includes tests for starting parking sessions and preventing duplicate
-parking attempts. See `TEST_PLAN.md` for a detailed description of coverage.
+## Notes
+- Tests use namespaced data per worker to avoid collisions.
+- Sessions are function-scoped to prevent state leakage.

--- a/conftest.py
+++ b/conftest.py
@@ -40,9 +40,11 @@ def session(config):
     s = requests.Session()
     try:
         api.login(s, config["base_url"], config["username"], config["password"])
-    except Exception as exc:  
+        yield s
+    except Exception as exc:
         pytest.fail(f"Auth failed in session fixture: {exc}")
-    return s
+    finally:
+        s.close()
 
 
 @pytest.fixture
@@ -59,15 +61,22 @@ def alt_session(config):
             config["alt_username"],
             config["alt_password"],
         )
+        yield s
     except Exception as exc:
         pytest.fail(f"Auth failed in alt_session fixture: {exc}")
-    return s
+    finally:
+        s.close()
 
 
 # ──────────────────────────────  GENERATORS  ───────────────────────────
 
 
+@pytest.fixture(scope="session")
+def worker_namespace(worker_id: str) -> str:
+    """Namespace for xdist workers; 'master' when not parallel."""
+    return worker_id if worker_id != "master" else "gw0"
+
 @pytest.fixture
-def unique_plate():
-    """Random 8-digit plate for each test."""
-    return random_plate()
+def unique_plate(worker_namespace: str):
+    """Random plate, namespaced per worker to avoid collisions."""
+    return f"{worker_namespace}-{random_plate()}"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     ui: Playwright end-to-end UI tests
+    api: API tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 beautifulsoup4
 playwright
 pytest-playwright
+pytest-xdist

--- a/tests/test_start_parking.py
+++ b/tests/test_start_parking.py
@@ -1,5 +1,8 @@
 """Tests related to *starting* parking sessions."""
 
+import pytest
+pytestmark = pytest.mark.api
+
 from utils.api import start_parking, count_plate_occurrences
 
 

--- a/tests/ui/test_start_parking_duplicate_plate_different_user.py
+++ b/tests/ui/test_start_parking_duplicate_plate_different_user.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 from playwright.sync_api import Page, expect
 import pytest
+pytestmark = pytest.mark.ui
 
 PLATE: str = "82743904"      # 8-digit plate (no letters, non-sequential)
 SLOT: str = "A1"             
@@ -37,10 +38,9 @@ def logout(page: Page) -> None:
 # --------------------------------------------------------------------------- #
 # Test case                                                                   #
 # --------------------------------------------------------------------------- #
-@pytest.mark.ui  
 def test_tc3_start_parking_duplicate_plate_different_user(
     page: Page,
-    config: Dict[str, str],          
+    config: Dict[str, str],
 ) -> None:
     """
     TC3 – Start Parking Duplicate Plate – Different User


### PR DESCRIPTION
- Add pytest-xdist and document parallel API runs
- Mark UI tests to run serially
- Introduce worker-namespaced unique test data
- Add .env.example and ignore .env
- Update README with install/run instructions

------
https://chatgpt.com/codex/tasks/task_e_689741f31634832e836189bf8979a211